### PR TITLE
Improved tooltips

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -157,7 +157,7 @@ function selectLevel(map, name) {
                                 return tooltipItems[0].xLabel + ' portal';
                         },
                         label: function (tooltipItems, data) {
-                            return data.datasets[tooltipItems.datasetIndex].label + ': ' + tooltipItems.yLabel + ' times';
+                            return tooltipItems.yLabel + ' times';
                         }
                     },
                     custom: function (tooltip) {

--- a/scripts.js
+++ b/scripts.js
@@ -96,6 +96,10 @@ function selectLevel(map, name) {
                 legend: {
                     display: false
                 },
+                tooltips: {
+                    mode: 'index',
+                    intersect: false
+                },
                 scales: {
                     xAxes: [{
                         type: 'linear',
@@ -123,6 +127,10 @@ function selectLevel(map, name) {
             options: {
                 legend: {
                     display: false
+                },
+                tooltips: {
+                    mode: 'index',
+                    intersect: false
                 },
                 scales: {
                     xAxes: [{

--- a/scripts.js
+++ b/scripts.js
@@ -106,6 +106,10 @@ function selectLevel(map, name) {
                             return + date.getMinutes() + ':' + date.getSeconds() + '.' + date.getMilliseconds().toString().substr(0,1) + ' - ' + tooltipItems.yLabel + ' times';
                         }
                     },
+                    custom: function (tooltip) {
+                        if (!tooltip) return;
+                        tooltip.displayColors = false;
+                    },
                     mode: 'index',
                     intersect: false
                 },
@@ -151,6 +155,10 @@ function selectLevel(map, name) {
                         label: function (tooltipItems, data) {
                             return data.datasets[tooltipItems.datasetIndex].label + ': ' + tooltipItems.yLabel + ' times';
                         }
+                    },
+                    custom: function (tooltip) {
+                        if (!tooltip) return;
+                        tooltip.displayColors = false;
                     },
                     mode: 'index',
                     intersect: false

--- a/scripts.js
+++ b/scripts.js
@@ -100,6 +100,12 @@ function selectLevel(map, name) {
                     display: false
                 },
                 tooltips: {
+                    callbacks: {
+                        label: function (tooltipItems, data) {
+                            var date = new Date(tooltipItems.xLabel * 1000);
+                            return + date.getMinutes() + ':' + date.getSeconds() + '.' + date.getMilliseconds().toString().substr(0,1) + ' - ' + tooltipItems.yLabel + ' times';
+                        }
+                    },
                     mode: 'index',
                     intersect: false
                 },

--- a/scripts.js
+++ b/scripts.js
@@ -101,9 +101,13 @@ function selectLevel(map, name) {
                 },
                 tooltips: {
                     callbacks: {
+                        title: function (tooltipItems, data) {
+                            var date = new Date(tooltipItems[0].xLabel * 1000);
+                            return + date.getMinutes() + ':' + date.getSeconds() + '.' + date.getMilliseconds().toString().substr(0, 1);
+                        },
                         label: function (tooltipItems, data) {
                             var date = new Date(tooltipItems.xLabel * 1000);
-                            return + date.getMinutes() + ':' + date.getSeconds() + '.' + date.getMilliseconds().toString().substr(0,1) + ' - ' + tooltipItems.yLabel + ' times';
+                            return tooltipItems.yLabel + ' times';
                         }
                     },
                     custom: function (tooltip) {

--- a/scripts.js
+++ b/scripts.js
@@ -141,6 +141,17 @@ function selectLevel(map, name) {
                     display: false
                 },
                 tooltips: {
+                    callbacks: {
+                        title: function (tooltipItems, data) {
+                            if (tooltipItems[0].xLabel != 1)
+                                return tooltipItems[0].xLabel + ' portals';
+                            else
+                                return tooltipItems[0].xLabel + ' portal';
+                        },
+                        label: function (tooltipItems, data) {
+                            return data.datasets[tooltipItems.datasetIndex].label + ': ' + tooltipItems.yLabel + ' times';
+                        }
+                    },
                     mode: 'index',
                     intersect: false
                 },

--- a/scripts.js
+++ b/scripts.js
@@ -93,6 +93,9 @@ function selectLevel(map, name) {
         timeChart = new Chart(document.getElementById("chart-time").getContext('2d'), {
             type: 'scatter',
             options: {
+                hover: {
+                    animationDuration: 1000
+                },
                 legend: {
                     display: false
                 },
@@ -125,6 +128,9 @@ function selectLevel(map, name) {
         portalChart = new Chart(document.getElementById("chart-portals").getContext('2d'), {
             type: 'bar',
             options: {
+                hover: {
+                    animationDuration: 1000
+                },
                 legend: {
                     display: false
                 },


### PR DESCRIPTION
This pull request improves the tooltips by not requiring super precision see accurate timestamps by showing them based of the x position and not requiring the mouse to intersect with the datapoint.

Updated the formatting for both charts as well, the portal tooltip reading

> **n Portals** 
> m times

and the times tooltip reading

> **mm:ss:S**
> n times

Additionally, the legend color has been removed, as both charts only have one dataset, thus requiring no color differentiation.